### PR TITLE
adds a conditional to not generate parentheses when there are no Arguments

### DIFF
--- a/src/graphql/graphql.js
+++ b/src/graphql/graphql.js
@@ -35,11 +35,10 @@ const construct = (type, methodName) => {
       }
 
       const finalFields = buildRequestedFields(fields)
+      const hasArguments = finalArgs.length ? finalArgs : ''
 
       return `${type} {
-        ${methodName} (
-          ${finalArgs}
-        ){
+        ${methodName} ${hasArguments} {
           ${finalFields}
           }
         }`


### PR DESCRIPTION
When we generate a query/mutation without any `Argument`, the field where it should contain such arguments is empty, containing only the opening and closing parentheses.

When you try to `parse` one of the generated values or try to run in the GraphQL Playground (or GraphiQL), an error is indicated due to the parentheses that are arranged in the wrong way.

<details>
<summary>Screenshot of the return of  the generated query/mutation with no Arguments and without the conditional</summary>
<img src="https://user-images.githubusercontent.com/47952043/110706941-5b9e8800-81d7-11eb-80ee-45240dacf4ad.png" />
</details>
<details>
<summary>Screenshot of the return of the generated query/mutation with no Arguments and with the conditional</summary>
<img src="https://user-images.githubusercontent.com/47952043/110707251-ca7be100-81d7-11eb-8b5b-72c8bc1d7ac8.png" />
</details>
<details>
<summary>A screenshot of when you try to parse a query/mutation with parentheses</summary>
<img src="https://user-images.githubusercontent.com/47952043/110707937-c603f800-81d8-11eb-9a6a-6bf12fff968e.png" />
</details>