### PR TITLE
[FIX] Integers being turned into strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoonit/utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple JS utility library to speed up development",
   "main": "yoo-utils.bundle.js",
   "repository": {

--- a/src/graphql/graphql.js
+++ b/src/graphql/graphql.js
@@ -160,7 +160,8 @@ const buildArgs = args => {
 
     if (Array.isArray(args[elm]) ||
         args[elm].constructor === Object ||
-        typeof args[elm] === 'boolean') {
+        typeof args[elm] === 'boolean' || 
+        Number.isInteger(args[elm])) {
       acc = acc + `${elm}: ${parseToGql(args[elm])},`
 
       return acc

--- a/src/graphql/graphql.js
+++ b/src/graphql/graphql.js
@@ -158,18 +158,10 @@ const buildArgs = args => {
       return acc
     }
 
-    if (Array.isArray(args[elm]) ||
-        args[elm].constructor === Object ||
-        typeof args[elm] === 'boolean' || 
-        Number.isInteger(args[elm])) {
-      acc = acc + `${elm}: ${parseToGql(args[elm])},`
+  acc = acc + `${elm}: ${parseToGql(args[elm])},`
 
-      return acc
-    }
+  return acc
 
-    acc = acc + `${elm}: "${args[elm]}",`
-
-    return acc
   }, '')
 }
 

--- a/src/graphql/graphql.test.js
+++ b/src/graphql/graphql.test.js
@@ -16,7 +16,7 @@ describe('GraphQL graphql Methods', () => {
             5123,
             { objTest: 'test' }
           ],
-          userId: 'noId',
+          userId: 123,
           token: 'myW3bTok3n',
           test: false,
           nullTest: null
@@ -30,7 +30,7 @@ describe('GraphQL graphql Methods', () => {
         'users'
       )).toBe(`mutation {
         mutationName (
-          value: [123,223,5123,{objTest:"test"}],userId: "noId",token: "myW3bTok3n",test: false,
+          value: [123,223,5123,{objTest:"test"}],userId: 123,token: "myW3bTok3n",test: false,
         ){
           status, message, id, names, users
           }
@@ -69,7 +69,7 @@ describe('GraphQL graphql Methods', () => {
     )).toBe(
       `query {
         queryName (
-          value: "value1",valueTwo: "2",token: "myW3bTok3n",
+          value: "value1",valueTwo: 2,token: "myW3bTok3n",
         ){
           status, message, messageTwo { messageTitle, messageBody, messageAlt { alternative }, messageAtt { att1, att2 } }
           }


### PR DESCRIPTION
# :bug: Integer arguments were being turned into strings inside buildArgs method

* Now buildArgs recognizes integer arguments and return them as integers.
* Tests were updated to cover this case
* Updates build version to 1.0.2